### PR TITLE
Fix cancel handler callback

### DIFF
--- a/src/MobileFeatures/widget/plugins/dialog.js
+++ b/src/MobileFeatures/widget/plugins/dialog.js
@@ -38,8 +38,8 @@ define([
                             //console.log("success: " + msg)
                         }); // called when the screenshot was hidden (almost instantly)
                     }
-                    if (args.handlerCancel) {
-                        args.handlerCancel();
+                    if (args.onCancel) {
+                        args.onCancel();
                     }
                 }
             }, "Confirm", [args.proceed, args.cancel]);


### PR DESCRIPTION
When calling mx.ui.confirmation with onCancel specified, the callback never happened. This pull request fixes this.