### PR TITLE
Set the initial connection status correctly

### DIFF
--- a/src/MobileFeatures/widget/plugins/classes.js
+++ b/src/MobileFeatures/widget/plugins/classes.js
@@ -90,7 +90,7 @@ define([
         },
 
         _enableConnectionDetection: function () {
-            this._toggleStatus(true);
+            this._onOnline();
             document.addEventListener("offline", lang.hitch(this, this._onOffline), false);
             document.addEventListener("online", lang.hitch(this, this._onOnline), false);
         },


### PR DESCRIPTION
Previous behavior: the widget assumes that the connection is online when it initializes
New behavior: the widget reads the actual connection status when it initializes.